### PR TITLE
Keep form values until the user resets them manually

### DIFF
--- a/web/src/app/state/app.state.ts
+++ b/web/src/app/state/app.state.ts
@@ -7,6 +7,7 @@ import {SafeResourceUrl} from '@angular/platform-browser';
 export class AppState {
   private _fields: any[] = [];
   private _imagePreview: SafeResourceUrl = '';
+  private _formValues: {[p: string]: any} = [];
 
   get fields(): any[] {
     return this._fields;
@@ -24,8 +25,17 @@ export class AppState {
     this._imagePreview = value;
   }
 
+  get formValues(): {[p: string]: any} {
+    return this._formValues;
+  }
+
+  set formValues(values: {[p: string]: any}) {
+    this._formValues = values;
+  }
+
   reset() {
     this._imagePreview = '';
     this._fields = [];
+    this._formValues = [];
   }
 }

--- a/web/src/app/steps/participant-information/participant-information.component.html
+++ b/web/src/app/steps/participant-information/participant-information.component.html
@@ -24,5 +24,7 @@
     <span>To switch input fields, press <b class="keyboard-key">TAB</b></span>
     <br/>
     <span>To show a preview, press <b class="keyboard-key">ENTER</b></span>
+    <br/>
+    <span>To clear all input fields, press <b class="keyboard-key">ESC</b></span>
   </div>
 </div>

--- a/web/src/app/steps/participant-information/participant-information.component.ts
+++ b/web/src/app/steps/participant-information/participant-information.component.ts
@@ -21,6 +21,14 @@ export class ParticipantInformationComponent implements OnInit, AfterViewInit {
 
   Direction = Direction;
 
+  private keyboardEventListeners = (ke: KeyboardEvent) => {
+    console.log(ke);
+    if (ke.code === 'Escape') {
+      this.state.reset();
+      this.form.reset();
+    }
+  }
+
   constructor(
     private infoService: InfoService,
     private previewService: PreviewService,
@@ -31,11 +39,15 @@ export class ParticipantInformationComponent implements OnInit, AfterViewInit {
     private router: Router,
     private messageService: MessageService,
   ) {
+    document.addEventListener('keydown', this.keyboardEventListeners);
   }
 
   ngOnInit() {
-    this.state.reset();
     this.getFields();
+  }
+
+  ngOnDestroy() {
+    document.removeEventListener('keydown', this.keyboardEventListeners)
   }
 
   ngAfterViewInit() {
@@ -46,10 +58,12 @@ export class ParticipantInformationComponent implements OnInit, AfterViewInit {
     this.infoService.getFields().subscribe((fields) => {
       this.fields = fields;
       this.form = this.formCreationService.toFormGroup(fields);
+      this.form.setValue(this.state.formValues);
     });
   }
 
   sendData() {
+    this.state.formValues = this.form.value;
     this.previewService.getPreview(this.form.value).subscribe((preview) => {
       this.state.fields = preview.fields;
       this.state.imagePreview = this.sanitizer.bypassSecurityTrustResourceUrl(preview.image);


### PR DESCRIPTION
This allows
- going back from the preview to modify values
- reprinting a badge without re-entering all values (e.g. if the printer jammed)